### PR TITLE
Prevent parsing of empty string for Date & DateTime

### DIFF
--- a/lib/happymapper/supported_types.rb
+++ b/lib/happymapper/supported_types.rb
@@ -110,11 +110,11 @@ module HappyMapper
     end
 
     register_type DateTime do |value|
-      DateTime.parse(value.to_s) if value
+      DateTime.parse(value.to_s) if value && !value.empty?
     end
 
     register_type Date do |value|
-      Date.parse(value.to_s) if value
+      Date.parse(value.to_s) if value && !value.empty?
     end
 
     register_type Boolean do |value|

--- a/spec/happymapper/item_spec.rb
+++ b/spec/happymapper/item_spec.rb
@@ -107,6 +107,11 @@ describe HappyMapper::Item do
       item.typecast(nil).should == nil
     end
 
+    it "should handle empty string Dates" do
+      item = HappyMapper::Item.new(:foo, Date)
+      item.typecast("").should == nil
+    end
+
     it "should work with DateTimes" do
       item = HappyMapper::Item.new(:foo, DateTime)
       item.typecast('2000-01-01 00:00:00').should == DateTime.new(2000, 1, 1, 0, 0, 0)
@@ -116,6 +121,12 @@ describe HappyMapper::Item do
       item = HappyMapper::Item.new(:foo, DateTime)
       item.typecast(nil).should == nil
     end
+
+    it "should handle empty string DateTimes" do
+      item = HappyMapper::Item.new(:foo, DateTime)
+      item.typecast("").should == nil
+    end
+
 
     it "should work with Boolean" do
       item = HappyMapper::Item.new(:foo, HappyMapper::Boolean)


### PR DESCRIPTION
Prevents an 'invalid date' error from being returned when parsing an empty string input.
